### PR TITLE
Add support for EmuTOS 256k ROMs

### DIFF
--- a/estyjs/io.js
+++ b/estyjs/io.js
@@ -289,6 +289,10 @@ EstyJs.io = function (opts) {
             throw "memory error";
         }
 
+        if ((addr & 0xFFFF00) == 0xFFFE00) {
+            throw "memory error";
+        }
+
         if ((addr & 1) == 0) return;
 
         //bug.say(sprintf('invalid io write $%06x', addr));
@@ -426,6 +430,10 @@ EstyJs.io = function (opts) {
         }
 
         if ((addr & 0xFFFF00) == 0xFF8900) {
+            return; //return undefined
+        }
+
+        if ((addr & 0xFFFF00) == 0xFFFE00) {
             return; //return undefined
         }
 

--- a/estyjs/io.js
+++ b/estyjs/io.js
@@ -263,7 +263,7 @@ EstyJs.io = function (opts) {
             return;
         }
 
-        if ((addr & 0xFFFA00) == 0xFFFA00) {
+        if ((addr & 0xFFFF00) == 0xFFFA00) {
             mfp.writeData(addr, val);
             return;
         }
@@ -396,7 +396,7 @@ EstyJs.io = function (opts) {
         }
 
 
-        if ((addr & 0xFFFA00) == 0xFFFA00) {
+        if ((addr & 0xFFFF00) == 0xFFFA00) {
             return mfp.readData(addr);
         }
 


### PR DESCRIPTION
This PR adds support to boot EmuTOS 256 kiB ROMs. Compared to the 192k ROMs, the 256k ROMs contain (among other things) a fully-featured desktop and a command-line interface (EmuCON), and thus provide an even better user experience.

PS: As project leader of EmuTOS I am happy that EstyJS is under active development again and delighted that you ship it with the current EmuTOS release.